### PR TITLE
Support composer-manager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ mysql:
 
 before_install:
   - composer self-update
-  #- cd ./tests
   - composer global require "lionsad/drupal_ti:1.*"
   - drupal-ti before_install
 
@@ -97,6 +96,7 @@ install:
   - drupal-ti install
 
 before_script:
+  - drupal-ti --include scripts/composer-manager.sh
   - drupal-ti before_script
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ env:
     - DRUPAL_TI_COVERAGE_FILE="build/logs/clover.xml"
 
     # Debug options
-    - DRUPAL_TI_DEBUG="-x -v"
+    # - DRUPAL_TI_DEBUG="-x -v"
     # Set to "all" to output all files, set to e.g. "xvfb selenium" or "selenium",
     # etc. to only output those channels.
     #- DRUPAL_TI_DEBUG_FILE_OUTPUT="selenium xvfb webserver"

--- a/scripts/composer-manager.sh
+++ b/scripts/composer-manager.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e $DRUPAL_TI_DEBUG
+
+# Ensure the right Drupal version is installed.
+# Note: This function is re-entrant.
+drupal_ti_ensure_drupal
+
+cd "$DRUPAL_TI_DRUPAL_DIR"
+drush dl composer_manager --yes
+drush pm-enable composer_manager --yes
+drush composer-manager-init


### PR DESCRIPTION
This is the best way for now until I can add proper support of composer-manager with tests, etc.

The --include will still be useful for any custom dependencies or other things that are needed.
